### PR TITLE
Added a prefix

### DIFF
--- a/lang/en/qtype_easyoselectjs.php
+++ b/lang/en/qtype_easyoselectjs.php
@@ -19,7 +19,7 @@
  *
  * @package    qtype
  * @subpackage easyoselectjs
- * @copyright  2014 onwards Carl LeBlond 
+ * @copyright  2014 onwards Carl LeBlond
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -27,7 +27,7 @@
 $string['addmoreanswerblanks'] = 'Blanks for {no} More Answers';
 $string['answermustbegiven'] = 'You must enter an answer if there is a grade or feedback.';
 $string['answerno'] = 'Answer {$a}';
-$string['pluginname'] = 'Select Atoms or Molecules (MarvinJS)';
+$string['pluginname'] = 'Chemistry - Select Atoms or Molecules (MarvinJS)';
 $string['pluginname_help'] = 'Students must select predefined atoms, molecules or functional groups.  You can ask questions such as; <ul><li>Select all the tertiary carbons below.</li><li>Select all chiral carbons in the following tsructure?</li><li>Select the longest chain of carbon atoms?</li></ul>';
 $string['pluginname_link'] = 'question/type/easyoselect';
 $string['pluginnameadding'] = 'Adding an Select Atoms or Molecules question';


### PR DESCRIPTION
Fix to issue #1

In order to group your chemistry related question types together, I
added a prefix "Chemistry" to the string ‚pluginname‘.
